### PR TITLE
Fix/python version

### DIFF
--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -6,10 +6,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
-cd $( brew --prefix )
-git checkout f2a764e ./Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
+BREW_PREFIX=$( brew --prefix )
+git checkout f2a764e ${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
 brew upgrade python
-git checkout -- ./Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
+git checkout -- ${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
 
 brew install --force lcov
 

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -6,10 +6,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
-BREW_PREFIX=$( brew --prefix )
-git checkout f2a764e ${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
+cd "$(brew --repo homebrew/core)"
+git checkout f2a764e Formula/python.rb
 brew upgrade python
-git checkout -- ${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
+git checkout -- Formula/python.rb
+cd $OLDPWD
 
 brew install --force lcov
 

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -5,7 +5,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
+cd $( brew --prefix )
+git checkout f2a764e ./Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
 brew upgrade python
+git checkout -- ./Homebrew/Library/Taps/homebrew/homebrew-core/Formula/python.rb
+
 brew install --force lcov
 
 # Installing conan

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -5,16 +5,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-brew update
-
-# Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
-cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
-ls -lah .
-git checkout f2a764e -- ./Formula/python.rb
-brew upgrade python
-git reset HEAD ./Formula/python.rb
-git checkout -- ./Formula/python.rb
-cd $OLDPWD
+brew upgrade pyenv
+export PATH=$HOME/.pyenv/shims:$HOME/.pyenv/versions/${TRAVIS_PYTHON_VERSION}/bin:$PATH
+pyenv install 3.6.5 -s
+pyenv init -
+pyenv local 3.6.5
 
 brew install --force lcov
 

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+brew update
+
 # Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
 cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
 ls -lah .

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -7,9 +7,10 @@
 
 # Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
 cd "$(brew --repo homebrew/core)"
-git checkout f2a764e Formula/python.rb
+git checkout f2a764e -- ./Formula/python.rb
 brew upgrade python
-git checkout -- Formula/python.rb
+git reset HEAD ./Formula/python.rb
+git checkout -- ./Formula/python.rb
 cd $OLDPWD
 
 brew install --force lcov

--- a/.CI/travis/install_osx.sh
+++ b/.CI/travis/install_osx.sh
@@ -6,7 +6,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Forcing Python 3.6.5_1. Pip packages using cython do not compile with 3.7.0.
-cd "$(brew --repo homebrew/core)"
+cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
+ls -lah .
 git checkout f2a764e -- ./Formula/python.rb
 brew upgrade python
 git reset HEAD ./Formula/python.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
           - ${HOME}/.conan
           - ${TRAVIS_BUILD_DIR}/cmake
           - ${TRAVIS_BUILD_DIR}/arrayfire
+          - $HOME/.pyenv
           - $HOME/Library/Caches/Homebrew
       before_install:
         - source .CI/travis/install_osx.sh
@@ -65,6 +66,7 @@ matrix:
           - ${HOME}/.conan
           - ${TRAVIS_BUILD_DIR}/cmake
           - ${TRAVIS_BUILD_DIR}/arrayfire
+          - $HOME/.pyenv
           - $HOME/Library/Caches/Homebrew
       before_install:
         - source .CI/travis/install_osx.sh


### PR DESCRIPTION
Brew installs Python 3.7.0, which causes problems installing conan and its dependencies.

The problem is in the packages using Cython, which do not compile.