### PR TITLE
Update documentation for installing doxygen and sphinx packages using…

### DIFF
--- a/doc/markdown/INSTALLATION.md
+++ b/doc/markdown/INSTALLATION.md
@@ -96,8 +96,10 @@ For linux, either a deb or a rpm installer package can be generated. This is don
 
 We use `sphinx + doxygen` to generate our documentation. You will need to install the following packages:
 
-- Sphinx: `brew install sphinx`.
-- Doxygen: `brew install doxygen`.
+As root:
+
+- Sphinx: `apt-get install python3-sphinx`.
+- Doxygen: `apt-get install doxygen`.
 - Read the Docs Theme: `pip install sphinx_rtd_theme`.
 - Breathe: `pip install breathe`.
 


### PR DESCRIPTION
… apt-get instead of brew for linux

### Description
- **Just some minor changes to adapt the installation documentation for linux operating system**.
We can install packages in linux using brew but is not natural most of the times.   

To install packages using brew in linux we have to install these packages as well:   

     apt-get install build-essential
     apt-get install linuxbrew-wrapper

Anyway, using brew in linux could create dependencies problem.

So for debian based linux distribution, as Ubuntu, we should better use its native package manager system.

In this case we will install sphinx and doxygen doing:

    apt-get install python3-sphinx
    apt-get install doxygen

### Tests
- My PR  does not need testing. It is just a documentation change.


### Benchmarks
- My PR  does not need benchmarks. It is just a documentation change.reason:



