### PR TITLE
Fix issue with findNBestOccurrences distances array type 

### DIFF
--- a/src/khiva/matrix.cpp
+++ b/src/khiva/matrix.cpp
@@ -553,7 +553,7 @@ void findBestNOccurrences(af::array q, af::array t, long n, af::array &distances
     af::sort(sortedDistances, sortedIndexes, distancesGlobal);
 
     indexes = sortedIndexes(af::seq(n), af::span, af::span);
-    distances = sortedDistances(af::seq(n), af::span, af::span).as(t.type());
+    distances = sortedDistances(af::seq(n), af::span, af::span);
 }
 
 void stomp(af::array ta, af::array tb, long m, af::array &profile, af::array &index) {


### PR DESCRIPTION
The type of the returned array 'distances' by the C binding
was of the same type as the input time series. When the input time
series was of type integer the distances were being returned truncated.

Make sure you have checked _all_ steps below.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Benchmarks
- [ ] My PR adds the following micro benchmarks __OR__ does not need benchmarks for this extremely good reason:


### Commits
- [ ] My commits have been squashed if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


## License
- [ ] Add a [Mozilla Public License 2.0 license header](http://mozilla.org/MPL/2.0/) to all the new files.


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
