### PR TITLE
Fix precission issue computing stddev

### DIFF
--- a/src/khiva/matrixInternal.cpp
+++ b/src/khiva/matrixInternal.cpp
@@ -52,13 +52,11 @@ void meanStdev(af::array t, af::array &a, long m, af::array &mean, af::array &st
     af::array mean_t_p2 = af::pow(mean, 2);
     // Variance
     af::array sigma_t2 = mean_t2 - mean_t_p2;
-    // Standard deviation
-    stdev = af::sqrt(sigma_t2);
-
-    double eps = (sigma_t2.type() == 0) ? EPSILON * 1e4 : EPSILON;
-
+    // Standard deviation 
+    double eps = (sigma_t2.type() == 0) ? EPSILON * 1e4 : EPSILON; 
     af::array lessThanEpsilon = eps >= sigma_t2;
     sigma_t2 = lessThanEpsilon * lessThanEpsilon.as(sigma_t2.type()) + !lessThanEpsilon * sigma_t2;
+    stdev = af::sqrt(sigma_t2);
 
     // Auxiliary variable to be used for the distance calculation
     a = (sum_t2 - 2 * sum_t * mean + m * mean_t_p2) / sigma_t2;


### PR DESCRIPTION
When using OpenCL backend some NaNs appear in the standard deviation due
to a precission issue.

Make sure you have checked _all_ steps below.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Benchmarks
- [ ] My PR adds the following micro benchmarks __OR__ does not need benchmarks for this extremely good reason:


### Commits
- [ ] My commits have been squashed if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


## License
- [ ] Add a [Mozilla Public License 2.0 license header](http://mozilla.org/MPL/2.0/) to all the new files.


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
